### PR TITLE
Get our xform performance to a reasonable place

### DIFF
--- a/apps/dump-sh/src/main.rs
+++ b/apps/dump-sh/src/main.rs
@@ -104,7 +104,7 @@ fn main() -> Fallible<()> {
             for sh_instr in shape.instrs.iter() {
                 if let sh::Instr::X86Code(x86) = sh_instr {
                     let mut pos = 0;
-                    for instr in &x86.bytecode.borrow().instrs {
+                    for instr in &x86.bytecode.instrs {
                         for operand in &instr.operands {
                             if let i386::Operand::Memory(memref) = operand {
                                 if let Ok(tramp) = shape.lookup_trampoline_by_offset(
@@ -146,7 +146,7 @@ fn main() -> Fallible<()> {
             let mut dedup = HashMap::new();
             for vinstr in shape.instrs {
                 if let sh::Instr::X86Code(x86) = vinstr {
-                    for instr in &x86.bytecode.borrow().instrs {
+                    for instr in &x86.bytecode.instrs {
                         for operand in &instr.operands {
                             if let i386::Operand::Memory(memref) = operand {
                                 let key = format!("{}", memref);

--- a/libs/fnt/src/lib.rs
+++ b/libs/fnt/src/lib.rs
@@ -19,7 +19,7 @@ use failure::{bail, ensure, Fallible};
 use i386::{ByteCode, Interpreter, Reg};
 use image::{ImageBuffer, LumaA};
 use peff::PE;
-use std::{cell::RefCell, collections::HashMap, mem, rc::Rc};
+use std::{collections::HashMap, mem};
 
 // Save chars to png when testing.
 const DUMP_CHARS: bool = false;
@@ -28,7 +28,7 @@ pub struct GlyphInfo {
     pub glyph_index: u8,
     pub glyph_char: String,
     pub width: i32,
-    pub bytecode: Rc<RefCell<ByteCode>>,
+    pub bytecode: ByteCode,
 }
 
 pub struct Fnt {
@@ -92,7 +92,7 @@ impl Fnt {
                     glyph_index,
                     glyph_char,
                     width,
-                    bytecode: bytecode.into_rc(),
+                    bytecode,
                 },
             );
         }
@@ -109,7 +109,7 @@ impl Fnt {
             }
             let glyph = &self.glyphs[&glyph_index];
             println!("{:<2} - {:04X}:", glyph.glyph_char, glyph.glyph_index);
-            println!("{}", glyph.bytecode.borrow().show_relative(0));
+            println!("{}", glyph.bytecode.show_relative(0));
 
             {
                 let mut interp = Interpreter::new();

--- a/libs/i386/src/disassembler.rs
+++ b/libs/i386/src/disassembler.rs
@@ -60,7 +60,7 @@ impl DisassemblyError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Reg {
     AL,
     BL,
@@ -205,7 +205,7 @@ impl fmt::Display for Reg {
 }
 
 // size @ [base + index*scale + disp]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MemRef {
     pub displacement: i32,
     pub base: Option<Reg>,
@@ -424,7 +424,7 @@ impl OperandDecodeState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Operand {
     Imm32(u32),
     Imm32s(i32),
@@ -852,7 +852,7 @@ impl OpPrefix {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Instr {
     pub memonic: Memonic,
     pub operands: Vec<Operand>,
@@ -989,7 +989,7 @@ impl fmt::Display for Instr {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ByteCode {
     pub start_addr: u32,
     pub size: u32,

--- a/libs/render/buffer/shape_chunk/examples/demo-instances.rs
+++ b/libs/render/buffer/shape_chunk/examples/demo-instances.rs
@@ -255,7 +255,7 @@ fn main() -> Fallible<()> {
     let mut flags_arr = [0u32; 2];
     draw_state.build_mask_into(
         draw_state.time_origin(),
-        f18_part.widgets().errata(),
+        f18_part.widgets().read().unwrap().errata(),
         &mut flags_arr[0..2],
     )?;
     let flags_buffer = CpuAccessibleBuffer::from_iter(
@@ -266,10 +266,10 @@ fn main() -> Fallible<()> {
 
     // Upload transforms
     let now = Instant::now();
-    let xforms_len = f18_part.widgets().num_transformer_floats();
+    let xforms_len = f18_part.widgets().read().unwrap().num_transformer_floats();
     let mut xforms = Vec::with_capacity(xforms_len);
     xforms.resize(xforms_len, 0f32);
-    f18_part.widgets().animate_into(
+    f18_part.widgets().write().unwrap().animate_into(
         &draw_state,
         draw_state.time_origin(),
         &now,

--- a/libs/render/buffer/shape_chunk/src/lib.rs
+++ b/libs/render/buffer/shape_chunk/src/lib.rs
@@ -21,7 +21,7 @@ mod upload;
 pub use chunk::{Chunk, ChunkId, ChunkPart, ClosedChunk, OpenChunk, ShapeId};
 pub use chunk_manager::ShapeChunkManager;
 pub use draw_state::DrawState;
-pub use upload::{DrawSelection, ShapeErrata, Vertex};
+pub use upload::{DrawSelection, ShapeErrata, ShapeWidgets, Vertex};
 
 mod test_vs {
     use vulkano_shaders::shader;
@@ -148,7 +148,8 @@ mod test {
         future.then_signal_fence_and_flush()?.wait(None)?;
 
         for shape_id in &all_shapes {
-            let widgets = chunk_man.part(*shape_id)?.widgets();
+            let lifetime = chunk_man.part(*shape_id)?.widgets();
+            let widgets = lifetime.read().unwrap();
             trace!("{} - {}", widgets.num_xforms(), widgets.name());
         }
 

--- a/libs/render/buffer/shape_chunk/src/upload.rs
+++ b/libs/render/buffer/shape_chunk/src/upload.rs
@@ -24,7 +24,6 @@ use pal::Palette;
 use pic::Pic;
 use sh::{Facet, FacetFlags, Instr, RawShape, VertexBuf, X86Code, X86Trampoline, SHAPE_LOAD_BASE};
 use std::{
-    cell::RefCell,
     collections::{HashMap, HashSet},
     time::Instant,
 };
@@ -449,7 +448,7 @@ impl Transformer {
             d * std::f32::consts::PI / 8192f32
         }
 
-        let mut vm = &mut self.vm;
+        let vm = &mut self.vm;
         for input in &self.inputs {
             let (loc, value) = match input {
                 TransformInput::CurrentTicks(loc) => {

--- a/libs/render/buffer/shape_chunk/src/upload.rs
+++ b/libs/render/buffer/shape_chunk/src/upload.rs
@@ -154,6 +154,7 @@ impl DrawSelection {
     }
 }
 
+#[derive(Clone)]
 pub enum TransformInput {
     CurrentTicks(u32),
     GearPosition(u32),
@@ -423,12 +424,10 @@ impl BufferPropsManager {
 // the virtual machine interpreter, already set up, the xform_id it maps to
 // for upload, the code and data offsets, and all inputs that need to be
 // configured and where to put them.
+#[derive(Clone)]
 pub struct Transformer {
     xform_id: u32,
-    // Note that mutability is an implementation detail here. We could construct
-    // a new one for each frame, for each instance, for each transform, but that
-    // would get expensive fast and we shouldn't actually be changing the state.
-    vm: RefCell<Interpreter>,
+    vm: Interpreter,
     code_offset: u32,
     data_offset: u32,
     inputs: Vec<TransformInput>,
@@ -441,7 +440,7 @@ impl Transformer {
     }
 
     pub fn transform(
-        &self,
+        &mut self,
         draw_state: &DrawState,
         start: &Instant,
         now: &Instant,
@@ -450,7 +449,7 @@ impl Transformer {
             d * std::f32::consts::PI / 8192f32
         }
 
-        let mut vm = self.vm.borrow_mut();
+        let mut vm = &mut self.vm;
         for input in &self.inputs {
             let (loc, value) = match input {
                 TransformInput::CurrentTicks(loc) => {
@@ -505,6 +504,7 @@ impl Transformer {
 
 // Contains information about what parts of the shape can be mutated by
 // standard actions. e.g. Gears, flaps, etc.
+#[derive(Clone)]
 pub struct ShapeWidgets {
     shape_name: String,
 
@@ -526,7 +526,7 @@ impl ShapeWidgets {
     }
 
     pub fn animate_into(
-        &self,
+        &mut self,
         draw_state: &DrawState,
         start: &Instant,
         now: &Instant,
@@ -534,9 +534,9 @@ impl ShapeWidgets {
     ) -> Fallible<()> {
         assert!(buffer.len() >= self.num_transformer_floats());
         let mut offset = 0;
-        for transformer in self.transformers.iter() {
+        for transformer in self.transformers.iter_mut() {
             let xform = transformer.transform(draw_state, start, now)?;
-            buffer[offset..].copy_from_slice(&xform);
+            buffer[offset..offset + 6].copy_from_slice(&xform);
             offset += 6;
         }
         Ok(())
@@ -674,7 +674,7 @@ impl ShapeUploader {
         sh: &'a RawShape,
     ) -> HashMap<&'a str, &'a X86Trampoline> {
         let mut out = HashMap::new();
-        for instr in &x86.bytecode.borrow().instrs {
+        for instr in &x86.bytecode.instrs {
             for operand in &instr.operands {
                 if let i386::Operand::Memory(memref) = operand {
                     if let Ok(tramp) = sh.lookup_trampoline_by_offset(
@@ -694,7 +694,7 @@ impl ShapeUploader {
     ) -> Fallible<HashMap<&'a str, &'a X86Trampoline>> {
         let mut out = HashMap::new();
         let mut push_value = 0;
-        for instr in &x86.bytecode.borrow().instrs {
+        for instr in &x86.bytecode.instrs {
             if instr.memonic == i386::Memonic::Push {
                 if let i386::Operand::Imm32s(v) = instr.operands[0] {
                     push_value = (v as u32).wrapping_sub(SHAPE_LOAD_BASE);
@@ -970,7 +970,7 @@ impl ShapeUploader {
 
         transformers.push(Transformer {
             xform_id,
-            vm: RefCell::new(interp),
+            vm: interp,
             code_offset: x86.code_offset(SHAPE_LOAD_BASE),
             data_offset: SHAPE_LOAD_BASE + xform.at_offset() as u32 + 2u32,
             inputs,

--- a/libs/render/draw/legacy_shape/src/upload.rs
+++ b/libs/render/draw/legacy_shape/src/upload.rs
@@ -691,7 +691,7 @@ impl ShapeUploader {
         sh: &'a RawShape,
     ) -> HashMap<&'a str, &'a X86Trampoline> {
         let mut out = HashMap::new();
-        for instr in &x86.bytecode.borrow().instrs {
+        for instr in &x86.bytecode.instrs {
             for operand in &instr.operands {
                 if let i386::Operand::Memory(memref) = operand {
                     if let Ok(tramp) = sh.lookup_trampoline_by_offset(
@@ -711,7 +711,7 @@ impl ShapeUploader {
     ) -> Fallible<HashMap<&'a str, &'a X86Trampoline>> {
         let mut out = HashMap::new();
         let mut push_value = 0;
-        for instr in &x86.bytecode.borrow().instrs {
+        for instr in &x86.bytecode.instrs {
             if instr.memonic == i386::Memonic::Push {
                 if let i386::Operand::Imm32s(v) = instr.operands[0] {
                     push_value = (v as u32).wrapping_sub(SHAPE_LOAD_BASE);

--- a/libs/sh/src/instr/code.rs
+++ b/libs/sh/src/instr/code.rs
@@ -20,7 +20,7 @@ use lazy_static::lazy_static;
 use log::trace;
 use peff::{Thunk, PE};
 use reverse::bs2s;
-use std::{cell::RefCell, cmp, collections::HashSet, mem, rc::Rc};
+use std::{cmp, collections::HashSet, mem};
 
 lazy_static! {
     pub static ref DATA_RELOCATIONS: HashSet<String> = {
@@ -231,7 +231,7 @@ pub struct X86Code {
     pub offset: usize,
     pub length: usize,
     pub data: *const u8,
-    pub bytecode: Rc<RefCell<ByteCode>>,
+    pub bytecode: ByteCode,
     pub have_header: bool,
 }
 
@@ -410,7 +410,7 @@ impl X86Code {
             offset: section_offset,
             length: section_length,
             data: pe.code[section_offset..].as_ptr(),
-            bytecode: bc.into_rc(),
+            bytecode: bc,
             have_header,
         })
     }
@@ -599,7 +599,7 @@ impl X86Code {
             ansi().green().bold(),
             hdr,
             ansi(),
-            self.bytecode.borrow().show_relative(show_offset).trim()
+            self.bytecode.show_relative(show_offset).trim()
         )
     }
 }

--- a/libs/world/Cargo.toml
+++ b/libs/world/Cargo.toml
@@ -13,5 +13,10 @@ pal = { path = "../pal" }
 shape_chunk = { path = "../render/buffer/shape_chunk" }
 
 [dev-dependencies]
+criterion = "0.2"
 omnilib = { path = "../omnilib" }
 window = { path = "../window" }
+
+[[bench]]
+name = "parallel-xform"
+harness = false

--- a/libs/world/benches/parallel-xform.rs
+++ b/libs/world/benches/parallel-xform.rs
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use failure::Fallible;
 use nalgebra::Point3;
 use omnilib::OmniLib;
@@ -25,14 +25,6 @@ use std::{
 };
 use window::{GraphicsConfigBuilder, GraphicsWindow};
 use world::{component::*, World};
-
-fn fibonacci(n: u64) -> u64 {
-    match n {
-        0 => 1,
-        1 => 1,
-        n => fibonacci(n - 1) + fibonacci(n - 2),
-    }
-}
 
 pub struct FlagUpdateSystem {
     start: Instant,
@@ -51,12 +43,11 @@ impl<'a> System<'a> for FlagUpdateSystem {
     fn run(&mut self, (shape_meshs, mut flag_buffers): Self::SystemData) {
         (&shape_meshs, &mut flag_buffers)
             .par_join()
-            .for_each(|(shape_mesh, mut flag_buffer)| {
-                shape_mesh.draw_state().build_mask_into(
-                    &self.start,
-                    flag_buffer.errata,
-                    &mut flag_buffer.buffer,
-                );
+            .for_each(|(shape_mesh, flag_buffer)| {
+                shape_mesh
+                    .draw_state()
+                    .build_mask_into(&self.start, flag_buffer.errata, &mut flag_buffer.buffer)
+                    .unwrap();
             });
     }
 }
@@ -83,7 +74,7 @@ impl<'a> System<'a> for XformUpdateSystem {
         let now = Instant::now();
         (&shape_meshs, &mut xform_buffers)
             .par_join()
-            .for_each(|(shape_mesh, mut xform_buffer)| {
+            .for_each(|(shape_mesh, xform_buffer)| {
                 WIDGET_CACHE.with(|widget_cache| {
                     match widget_cache.borrow_mut().entry(xform_buffer.shape_id) {
                         Entry::Occupied(mut e) => {
@@ -126,8 +117,8 @@ fn set_up_world() -> Fallible<World> {
     )?;
 
     let part = unsafe { upload.part(shape_id) };
-    for i in 0..10_000 {
-        let ent = world.create_flyer(shape_id, Point3::new(0f64, 0f64, 0f64), part)?;
+    for _ in 0..10_000 {
+        let _ent = world.create_flyer(shape_id, Point3::new(0f64, 0f64, 0f64), part)?;
     }
     Ok(world)
 }

--- a/libs/world/benches/parallel-xform.rs
+++ b/libs/world/benches/parallel-xform.rs
@@ -1,0 +1,153 @@
+// This file is part of OpenFA.
+//
+// OpenFA is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// OpenFA is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use failure::Fallible;
+use nalgebra::Point3;
+use omnilib::OmniLib;
+use shape_chunk::{DrawSelection, OpenChunk, ShapeId, ShapeWidgets};
+use specs::prelude::*;
+use std::{
+    cell::RefCell,
+    collections::{hash_map::Entry, HashMap},
+    time::Instant,
+};
+use window::{GraphicsConfigBuilder, GraphicsWindow};
+use world::{component::*, World};
+
+fn fibonacci(n: u64) -> u64 {
+    match n {
+        0 => 1,
+        1 => 1,
+        n => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+pub struct FlagUpdateSystem {
+    start: Instant,
+}
+impl FlagUpdateSystem {
+    pub fn new(start: &Instant) -> Self {
+        Self { start: *start }
+    }
+}
+impl<'a> System<'a> for FlagUpdateSystem {
+    type SystemData = (
+        ReadStorage<'a, ShapeMesh>,
+        WriteStorage<'a, ShapeMeshFlagBuffer>,
+    );
+
+    fn run(&mut self, (shape_meshs, mut flag_buffers): Self::SystemData) {
+        (&shape_meshs, &mut flag_buffers)
+            .par_join()
+            .for_each(|(shape_mesh, mut flag_buffer)| {
+                shape_mesh.draw_state().build_mask_into(
+                    &self.start,
+                    flag_buffer.errata,
+                    &mut flag_buffer.buffer,
+                );
+            });
+    }
+}
+
+thread_local! {
+    pub static WIDGET_CACHE: RefCell<HashMap<ShapeId, ShapeWidgets>> = RefCell::new(HashMap::new());
+}
+
+pub struct XformUpdateSystem {
+    start: Instant,
+}
+impl XformUpdateSystem {
+    pub fn new(start: &Instant) -> Self {
+        Self { start: *start }
+    }
+}
+impl<'a> System<'a> for XformUpdateSystem {
+    type SystemData = (
+        ReadStorage<'a, ShapeMesh>,
+        WriteStorage<'a, ShapeMeshXformBuffer>,
+    );
+
+    fn run(&mut self, (shape_meshs, mut xform_buffers): Self::SystemData) {
+        let now = Instant::now();
+        (&shape_meshs, &mut xform_buffers)
+            .par_join()
+            .for_each(|(shape_mesh, mut xform_buffer)| {
+                WIDGET_CACHE.with(|widget_cache| {
+                    match widget_cache.borrow_mut().entry(xform_buffer.shape_id) {
+                        Entry::Occupied(mut e) => {
+                            e.get_mut()
+                                .animate_into(
+                                    shape_mesh.draw_state(),
+                                    &self.start,
+                                    &now,
+                                    &mut xform_buffer.buffer,
+                                )
+                                .unwrap();
+                        }
+                        Entry::Vacant(e) => {
+                            let widgets = xform_buffer.widgets.read().unwrap().clone();
+                            e.insert(widgets);
+                        }
+                    }
+                });
+            });
+    }
+}
+
+fn set_up_world() -> Fallible<World> {
+    let omni = OmniLib::new_for_test_in_games(&["FA"])?;
+    let world = World::new(omni.library("FA"))?;
+    let window = GraphicsWindow::new(&GraphicsConfigBuilder::new().build())?;
+    let mut upload = OpenChunk::new(&window)?;
+
+    // Has a continuously updating transform / rotation.
+    // Has flags that may get updated at any time via AI or player:
+    //    AB, hook, flaps, aileron, gear, bay, brake, rudder, alive/dead, animation, sams, ejects
+    // Has xforms tracking motion for modified state via AI/player:
+    //    canard, ab, gear, sweep
+    let shape_id = upload.upload_shape(
+        "F31.SH",
+        DrawSelection::NormalModel,
+        world.system_palette(),
+        world.library(),
+        &window,
+    )?;
+
+    let part = unsafe { upload.part(shape_id) };
+    for i in 0..10_000 {
+        let ent = world.create_flyer(shape_id, Point3::new(0f64, 0f64, 0f64), part)?;
+    }
+    Ok(world)
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Set up world
+    let start = Instant::now();
+    let world = set_up_world().unwrap();
+
+    let mut update_dispatcher = DispatcherBuilder::new()
+        .with(FlagUpdateSystem::new(&start), "flag-update", &[])
+        .with(XformUpdateSystem::new(&start), "xform-update", &[])
+        .build();
+
+    c.bench_function("update all flags", move |b| {
+        b.iter(|| {
+            world.run(&mut update_dispatcher);
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/libs/world/src/component/mod.rs
+++ b/libs/world/src/component/mod.rs
@@ -18,6 +18,8 @@ pub mod transform;
 pub mod wheeled_dynamics;
 
 pub use flight_dynamics::FlightDynamics;
-pub use shape_mesh::{ShapeMesh, ShapeMeshFlagBuffer, ShapeMeshTransformBuffer};
+pub use shape_mesh::{
+    ShapeMesh, ShapeMeshFlagBuffer, ShapeMeshTransformBuffer, ShapeMeshXformBuffer,
+};
 pub use transform::Transform;
 pub use wheeled_dynamics::WheeledDynamics;

--- a/libs/world/src/component/shape_mesh.rs
+++ b/libs/world/src/component/shape_mesh.rs
@@ -12,8 +12,9 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
-use shape_chunk::{DrawState, ShapeErrata, ShapeId};
+use shape_chunk::{DrawState, ShapeErrata, ShapeId, ShapeWidgets};
 use specs::{Component, VecStorage};
+use std::sync::{Arc, RwLock};
 
 pub struct ShapeMesh {
     shape_id: ShapeId,
@@ -66,6 +67,27 @@ impl ShapeMeshFlagBuffer {
         Self {
             buffer: [0u32; 2],
             errata,
+        }
+    }
+}
+
+pub struct ShapeMeshXformBuffer {
+    pub shape_id: ShapeId,
+    pub buffer: Vec<f32>,
+    pub widgets: Arc<RwLock<ShapeWidgets>>,
+}
+impl Component for ShapeMeshXformBuffer {
+    type Storage = VecStorage<Self>;
+}
+impl ShapeMeshXformBuffer {
+    pub fn new(shape_id: ShapeId, widgets: Arc<RwLock<ShapeWidgets>>) -> Self {
+        let num_floats = widgets.read().unwrap().num_transformer_floats();
+        let mut buffer = Vec::with_capacity(num_floats);
+        buffer.resize(num_floats, 0f32);
+        Self {
+            shape_id,
+            buffer,
+            widgets,
         }
     }
 }

--- a/libs/world/src/lib.rs
+++ b/libs/world/src/lib.rs
@@ -13,8 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
 pub mod component;
+pub mod system;
 
-use crate::component::*;
+pub use crate::{
+    component::{
+        flight_dynamics::FlightDynamics,
+        shape_mesh::{
+            ShapeMesh, ShapeMeshFlagBuffer, ShapeMeshTransformBuffer, ShapeMeshXformBuffer,
+        },
+        transform::Transform,
+        wheeled_dynamics::WheeledDynamics,
+    },
+    system::shape_mesh::{FlagUpdateSystem, XformUpdateSystem},
+};
 use failure::Fallible;
 use lib::Library;
 use nalgebra::Point3;

--- a/libs/world/src/lib.rs
+++ b/libs/world/src/lib.rs
@@ -41,6 +41,7 @@ impl World {
         ecs.register::<ShapeMesh>();
         ecs.register::<ShapeMeshTransformBuffer>();
         ecs.register::<ShapeMeshFlagBuffer>();
+        ecs.register::<ShapeMeshXformBuffer>();
         ecs.register::<Transform>();
 
         Ok(Self {
@@ -86,6 +87,8 @@ impl World {
         position: Point3<f64>,
         part: &ChunkPart,
     ) -> Fallible<Entity> {
+        let widget_ref = part.widgets();
+        let widgets = widget_ref.read().unwrap();
         Ok(self
             .ecs
             .write()
@@ -96,7 +99,8 @@ impl World {
             .with(FlightDynamics::new())
             .with(ShapeMesh::new(shape_id))
             .with(ShapeMeshTransformBuffer::new())
-            .with(ShapeMeshFlagBuffer::new(part.widgets().errata()))
+            .with(ShapeMeshFlagBuffer::new(widgets.errata()))
+            .with(ShapeMeshXformBuffer::new(shape_id, part.widgets()))
             .build())
     }
 

--- a/libs/world/src/system/mod.rs
+++ b/libs/world/src/system/mod.rs
@@ -12,7 +12,4 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
-pub mod flight_dynamics;
 pub mod shape_mesh;
-pub mod transform;
-pub mod wheeled_dynamics;

--- a/libs/world/src/system/shape_mesh.rs
+++ b/libs/world/src/system/shape_mesh.rs
@@ -1,0 +1,101 @@
+// This file is part of OpenFA.
+//
+// OpenFA is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// OpenFA is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
+use crate::component::shape_mesh::*;
+use shape_chunk::{ShapeId, ShapeWidgets};
+use specs::prelude::*;
+use std::{
+    cell::RefCell,
+    collections::{hash_map::Entry, HashMap},
+    time::Instant,
+};
+
+thread_local! {
+    pub static WIDGET_CACHE: RefCell<HashMap<ShapeId, ShapeWidgets>> = RefCell::new(HashMap::new());
+}
+
+pub struct XformUpdateSystem {
+    start: Instant,
+}
+impl XformUpdateSystem {
+    pub fn new(start: &Instant) -> Self {
+        Self { start: *start }
+    }
+}
+impl<'a> System<'a> for XformUpdateSystem {
+    type SystemData = (
+        ReadStorage<'a, ShapeMesh>,
+        WriteStorage<'a, ShapeMeshXformBuffer>,
+    );
+
+    fn run(&mut self, (shape_meshs, mut xform_buffers): Self::SystemData) {
+        let now = Instant::now();
+        (&shape_meshs, &mut xform_buffers)
+            .par_join()
+            .for_each(|(shape_mesh, xform_buffer)| {
+                WIDGET_CACHE.with(|widget_cache| {
+                    match widget_cache.borrow_mut().entry(xform_buffer.shape_id) {
+                        Entry::Occupied(mut e) => {
+                            e.get_mut()
+                                .animate_into(
+                                    shape_mesh.draw_state(),
+                                    &self.start,
+                                    &now,
+                                    &mut xform_buffer.buffer,
+                                )
+                                .unwrap();
+                        }
+                        Entry::Vacant(e) => {
+                            let mut widgets = xform_buffer.widgets.read().unwrap().clone();
+                            widgets
+                                .animate_into(
+                                    shape_mesh.draw_state(),
+                                    &self.start,
+                                    &now,
+                                    &mut xform_buffer.buffer,
+                                )
+                                .unwrap();
+                            e.insert(widgets);
+                        }
+                    }
+                });
+            });
+    }
+}
+
+pub struct FlagUpdateSystem {
+    start: Instant,
+}
+impl FlagUpdateSystem {
+    pub fn new(start: &Instant) -> Self {
+        Self { start: *start }
+    }
+}
+impl<'a> System<'a> for FlagUpdateSystem {
+    type SystemData = (
+        ReadStorage<'a, ShapeMesh>,
+        WriteStorage<'a, ShapeMeshFlagBuffer>,
+    );
+
+    fn run(&mut self, (shape_meshs, mut flag_buffers): Self::SystemData) {
+        (&shape_meshs, &mut flag_buffers)
+            .par_join()
+            .for_each(|(shape_mesh, flag_buffer)| {
+                shape_mesh
+                    .draw_state()
+                    .build_mask_into(&self.start, flag_buffer.errata, &mut flag_buffer.buffer)
+                    .unwrap();
+            });
+    }
+}


### PR DESCRIPTION
This approach gets us roughly 1.8M xforms per second. This is equivalent to about 30K WNDMLL.SH or 1.8K F31.SH.

The basic strategy is to lazily clone a shape's Transformers into thread local storage the first time we see it. This way we don't have to take any locks in order to get a mutable reference to run the VM. The upshot is that we are finally gated purely on the performance of our quick and dirty x86 interpreter implementation.

The performance detail this leaves out is getting the computed xforms uploaded to GPU memory. That will have to come next.