### PR TITLE
Fix shape animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ apps/**/test_data/
 dump/
 test_data/
 research/
+.__openfa_cache__

--- a/TODO
+++ b/TODO
@@ -1,0 +1,24 @@
+TODO
+====
+
+An unsorted list of project ideas, in case I run out of things to do. Some of these will
+inevitably be stale or already done.
+
+* Let there be light
+Now that we have our buffers in a way that we can inject them wherever we need, we can access
+the atmosphere parameters from the Terrain and Shape draw calls. We can use this data to light
+those entities up properly so they're not just full-bright.
+
+* Draw regalia on planes
+It's a bit embarrasing that this isn't already done.
+
+* Flight dynamics model
+How hard could this be? :scream:
+
+* Figure out how high terrain is.
+We fudged this with a good looking constant. Would be nice to have units on this.
+
+* Shape exporter
+We want to be able to load and show non-SH shapes, e.g. as an override for old and busted models.
+Once we have that capability it is a reasonable jump to render to Janes SH files.
+

--- a/apps/show-sh/src/main.rs
+++ b/apps/show-sh/src/main.rs
@@ -141,24 +141,15 @@ fn main() -> Fallible<()> {
         slot_id,
         shape_id,
         shape_instance_buffer.borrow().part(shape_id),
-        Point3::new(0f32, 0f32, 1000f32),
+        Point3::new(0f32, 0f32, 0f32),
         &UnitQuaternion::identity(),
     )?;
     shape_instance_buffer
         .borrow_mut()
         .ensure_uploaded(&mut gpu)?;
 
-    /*
-    let mut update = |f: &mut dyn FnMut(&mut DrawState)| {
-        galaxy
-            .world_mut()
-            .get_component_mut::<ShapeComponent>(shape_entity)
-            .map(|mut shape| {
-                let ds: &mut DrawState = &mut shape.draw_state;
-                f(ds);
-            });
-    };
-    */
+    let mut camera = ArcBallCamera::new(gpu.aspect_ratio(), 0.001, 3.4e+38);
+    camera.set_target(0f64, 0f64, 0f64);
 
     ///////////////////////////////////////////////////////////
     let atmosphere_buffer = AtmosphereBuffer::new(&mut gpu)?;
@@ -194,9 +185,6 @@ fn main() -> Fallible<()> {
         .with_horizontal_anchor(TextAnchorH::Right)
         .with_vertical_position(TextPositionV::Bottom)
         .with_vertical_anchor(TextAnchorV::Bottom);
-
-    let mut camera = ArcBallCamera::new(gpu.aspect_ratio(), 0.001, 3.4e+38);
-    camera.set_target(0f64, 0f64, 1000f64);
 
     loop {
         let loop_start = Instant::now();

--- a/apps/show-sh/src/main.rs
+++ b/apps/show-sh/src/main.rs
@@ -26,7 +26,7 @@ use nalgebra::{Point3, UnitQuaternion, Vector3};
 use omnilib::{make_opt_struct, OmniLib};
 use screen_text::ScreenTextRenderPass;
 use shape::ShapeRenderPass;
-use shape_instance::{DrawSelection, DrawState, ShapeComponent, ShapeInstanceBuffer};
+use shape_instance::{DrawSelection, DrawState, ShapeInstanceBuffer, ShapeState};
 use simplelog::{Config, LevelFilter, TermLogger};
 use skybox::SkyboxRenderPass;
 use stars::StarsBuffer;
@@ -64,7 +64,7 @@ macro_rules! update {
     ($galaxy:ident, $shape_entity:ident, $func:ident) => {{
         $galaxy
             .world_mut()
-            .get_component_mut::<ShapeComponent>($shape_entity)
+            .get_component_mut::<ShapeState>($shape_entity)
             .map(|mut shape| {
                 let ds: &mut DrawState = &mut shape.draw_state;
                 ds.$func();
@@ -74,7 +74,7 @@ macro_rules! update {
     ($galaxy:ident, $shape_entity:ident, $func:ident, $arg:expr) => {{
         $galaxy
             .world_mut()
-            .get_component_mut::<ShapeComponent>($shape_entity)
+            .get_component_mut::<ShapeState>($shape_entity)
             .map(|mut shape| {
                 let ds: &mut DrawState = &mut shape.draw_state;
                 ds.$func($arg);
@@ -129,7 +129,7 @@ fn main() -> Fallible<()> {
 
     let shape_instance_buffer = ShapeInstanceBuffer::new(gpu.device())?;
 
-    let (shape_id, slot_id) = shape_instance_buffer
+    let (fuel_shape_id, fuel_slot_id) = shape_instance_buffer
         .borrow_mut()
         .upload_and_allocate_slot(
             "FUEL.SH",
@@ -139,14 +139,14 @@ fn main() -> Fallible<()> {
             &mut gpu,
         )?;
     galaxy.create_building(
-        slot_id,
-        shape_id,
-        shape_instance_buffer.borrow().part(shape_id),
+        fuel_slot_id,
+        fuel_shape_id,
+        shape_instance_buffer.borrow().part(fuel_shape_id),
         Point3::new(0f32, 0f32, 0f32),
         &UnitQuaternion::identity(),
     )?;
 
-    let (shape_id, slot_id) = shape_instance_buffer
+    let (f18_shape_id, f18_slot_id) = shape_instance_buffer
         .borrow_mut()
         .upload_and_allocate_slot(
             &shape_name,
@@ -156,14 +156,13 @@ fn main() -> Fallible<()> {
             &mut gpu,
         )?;
     let ent = galaxy.create_building(
-        slot_id,
-        shape_id,
-        shape_instance_buffer.borrow().part(shape_id),
+        f18_slot_id,
+        f18_shape_id,
+        shape_instance_buffer.borrow().part(f18_shape_id),
         Point3::new(0f32, -10f32, 0f32),
         &UnitQuaternion::identity(),
     )?;
 
-    /*
     let (shape_id, slot_id) = shape_instance_buffer
         .borrow_mut()
         .upload_and_allocate_slot(
@@ -173,7 +172,7 @@ fn main() -> Fallible<()> {
             galaxy.library(),
             &mut gpu,
         )?;
-    let ent1 = galaxy.create_building(
+    galaxy.create_building(
         slot_id,
         shape_id,
         shape_instance_buffer.borrow().part(shape_id),
@@ -190,14 +189,13 @@ fn main() -> Fallible<()> {
             galaxy.library(),
             &mut gpu,
         )?;
-    let ent2 = galaxy.create_building(
+    galaxy.create_building(
         slot_id,
         shape_id,
         shape_instance_buffer.borrow().part(shape_id),
         Point3::new(-3f32, -10f32, 3f32),
         &UnitQuaternion::identity(),
     )?;
-    */
 
     shape_instance_buffer
         .borrow_mut()
@@ -337,7 +335,7 @@ fn main() -> Fallible<()> {
 
         let ds = galaxy
             .world()
-            .get_component::<ShapeComponent>(ent)
+            .get_component::<ShapeState>(ent)
             .unwrap()
             .draw_state;
         let params = format!(

--- a/libs/galaxy/Cargo.toml
+++ b/libs/galaxy/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 
 [dependencies]
 failure = "^ 0.1.2"
-legion = { git="https://github.com/TomGillen/legion", rev="23a0b29c0ddefa05dcde39fc0ce73629fa0abf40"}
+#legion = { git="https://github.com/TomGillen/legion", rev="23a0b29c0ddefa05dcde39fc0ce73629fa0abf40"}
+legion = { git="https://github.com/jaynus/legion", branch="fix_tag"}
 nalgebra = "^ 0.18"
 lib = { path = "../lib" }
 pal = { path = "../pal" }

--- a/libs/galaxy/src/lib.rs
+++ b/libs/galaxy/src/lib.rs
@@ -14,7 +14,7 @@
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
 pub use legion::entity::Entity;
 pub use universe::{
-    component::{Rotation, Transform},
+    component::{Rotation, Scale, Transform},
     FEET_TO_DAM, FEET_TO_HM, FEET_TO_KM, FEET_TO_M,
 };
 
@@ -26,6 +26,7 @@ use pal::Palette;
 use shape_chunk::{ChunkPart, ShapeId};
 use shape_instance::{
     ShapeComponent, ShapeFlagBuffer, ShapeRefComp, ShapeTransformBuffer, ShapeXformBuffer, SlotId,
+    SHAPE_UNIT_TO_FEET,
 };
 use std::{sync::Arc, time::Instant};
 
@@ -97,6 +98,7 @@ impl Galaxy {
             vec![(
                 Transform::new(position.coords),
                 Rotation::new(*rotation),
+                Scale::new(SHAPE_UNIT_TO_FEET * FEET_TO_HM),
                 ShapeComponent::new(slot_id, widgets.errata()),
                 ShapeTransformBuffer::default(),
                 ShapeFlagBuffer::default(),

--- a/libs/galaxy/src/lib.rs
+++ b/libs/galaxy/src/lib.rs
@@ -25,8 +25,8 @@ use nalgebra::{Point3, UnitQuaternion};
 use pal::Palette;
 use shape_chunk::{ChunkPart, ShapeId};
 use shape_instance::{
-    ShapeComponent, ShapeFlagBuffer, ShapeRefComp, ShapeTransformBuffer, ShapeXformBuffer, SlotId,
-    SHAPE_UNIT_TO_FEET,
+    ShapeFlagBuffer, ShapeRef, ShapeSlot, ShapeState, ShapeTransformBuffer, ShapeXformBuffer,
+    SlotId, SHAPE_UNIT_TO_FEET,
 };
 use std::{sync::Arc, time::Instant};
 
@@ -94,12 +94,14 @@ impl Galaxy {
         let widget_ref = part.widgets();
         let widgets = widget_ref.read().unwrap();
         let entities = self.legion_world.insert(
-            (ShapeRefComp::new(shape_id),),
+            (),
             vec![(
                 Transform::new(position.coords),
                 Rotation::new(*rotation),
                 Scale::new(SHAPE_UNIT_TO_FEET * FEET_TO_HM),
-                ShapeComponent::new(slot_id, widgets.errata()),
+                ShapeRef::new(shape_id),
+                ShapeSlot::new(slot_id),
+                ShapeState::new(widgets.errata()),
                 ShapeTransformBuffer::default(),
                 ShapeFlagBuffer::default(),
             )],
@@ -124,7 +126,7 @@ impl Galaxy {
             .create_entity()
             .with(Transform::new(position, UnitQuaternion::identity()))
             .with(WheeledDynamics::new())
-            .with(ShapeComponent::new(slot_id, shape_id))
+            .with(ShapeSlot::new(slot_id, shape_id))
             .build())
     }
 

--- a/libs/render-wgpu/buffer/shape_chunk/include/include_shape.glsl
+++ b/libs/render-wgpu/buffer/shape_chunk/include/include_shape.glsl
@@ -41,19 +41,19 @@ mat3 from_euler_angles(float roll, float pitch, float yaw)
     );
 }
 
-mat4 matrix_for_xform(float xform[6]) {
-    // ma.xform_data[(6 * xform_id) + 0]
+mat4 matrix_for_xform(float xform[8]) {
     float t0 = xform[0];
     float t1 = xform[1];
     float t2 = xform[2];
     float r0 = xform[3];
     float r1 = xform[4];
     float r2 = xform[5];
+    float s = xform[6];
     mat4 trans = mat4(
-        1.0, 0.0, 0.0, 0.0,
-        0.0, 1.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0,
-        t0,  t1,  t2, 1.0
+          s, 0.0, 0.0, 0.0,
+        0.0,   s, 0.0, 0.0,
+        0.0, 0.0,   s, 0.0,
+         t0,  t1,  t2, 1.0
     );
     mat4 rot = mat4(from_euler_angles(r0, r1, r2));
     return trans * rot;

--- a/libs/render-wgpu/buffer/shape_chunk/src/upload.rs
+++ b/libs/render-wgpu/buffer/shape_chunk/src/upload.rs
@@ -23,7 +23,6 @@ use lazy_static::lazy_static;
 use lib::Library;
 use log::trace;
 use memoffset::offset_of;
-use nalgebra::Vector3;
 use pal::Palette;
 use pic::Pic;
 use sh::{Facet, FacetFlags, Instr, RawShape, VertexBuf, X86Code, X86Trampoline, SHAPE_LOAD_BASE};
@@ -32,7 +31,6 @@ use std::{
     mem,
     time::Instant,
 };
-use universe::FEET_TO_HM;
 
 const MAX_XFORM_ID: u32 = 32;
 
@@ -702,13 +700,6 @@ impl ShapeUploader {
                 xform_id: MAX_XFORM_ID,
             });
         for v in vert_buf.vertices() {
-            let mut v0 = Vector3::new(f32::from(v[0]), f32::from(-v[2]), f32::from(-v[1]));
-
-            // FIXME: blowing these up so we can see them on the map
-            // WTF: if we multiply by 4, everything lines up, otherwise not. Why?!?
-            // Note: this has to be done via a scale matrix so that our XForms line up.
-            //v0 *= FEET_TO_HM * 4f32;
-
             vert_pool.push(Vertex {
                 // Color and Tex Coords will be filled out by the
                 // face when we move this into the verts list.
@@ -716,7 +707,7 @@ impl ShapeUploader {
                 tex_coord: [0f32, 0f32],
                 // Base position, flags, and the xform are constant
                 // for this entire buffer, independent of the face.
-                position: [v0[0], v0[1], v0[2]],
+                position: [f32::from(v[0]), f32::from(-v[2]), f32::from(-v[1])],
                 flags0: (props.flags.bits() & 0xFFFF_FFFF) as u32,
                 flags1: (props.flags.bits() >> 32) as u32,
                 xform_id: props.xform_id,

--- a/libs/render-wgpu/buffer/shape_chunk/src/upload.rs
+++ b/libs/render-wgpu/buffer/shape_chunk/src/upload.rs
@@ -34,6 +34,8 @@ use std::{
 };
 use universe::FEET_TO_HM;
 
+const MAX_XFORM_ID: u32 = 32;
+
 bitflags! {
     pub struct VertexFlags: u64 {
         const NONE                 = 0x0000_0000_0000_0000;
@@ -697,13 +699,16 @@ impl ShapeUploader {
             .unwrap_or_else(|| BufferProps {
                 context: "Static".to_owned(),
                 flags: VertexFlags::STATIC,
-                xform_id: 0,
+                xform_id: MAX_XFORM_ID,
             });
         for v in vert_buf.vertices() {
             let mut v0 = Vector3::new(f32::from(v[0]), f32::from(-v[2]), f32::from(-v[1]));
+
             // FIXME: blowing these up so we can see them on the map
             // WTF: if we multiply by 4, everything lines up, otherwise not. Why?!?
-            v0 *= FEET_TO_HM * 4f32;
+            // Note: this has to be done via a scale matrix so that our XForms line up.
+            //v0 *= FEET_TO_HM * 4f32;
+
             vert_pool.push(Vertex {
                 // Color and Tex Coords will be filled out by the
                 // face when we move this into the verts list.
@@ -1192,7 +1197,7 @@ impl ShapeUploader {
                         if let Some(props) = result.prop_man.props.get(&vert_buf.at_offset()) {
                             props.xform_id
                         } else {
-                            0
+                            MAX_XFORM_ID
                         };
                 }
                 _ => {}

--- a/libs/render-wgpu/buffer/shape_instance/Cargo.toml
+++ b/libs/render-wgpu/buffer/shape_instance/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2018"
 [dependencies]
 failure = "^ 0.1.2"
 nalgebra = "^ 0.18"
-legion = { git="https://github.com/TomGillen/legion", rev="23a0b29c0ddefa05dcde39fc0ce73629fa0abf40"}
+#legion = { git="https://github.com/TomGillen/legion", rev="23a0b29c0ddefa05dcde39fc0ce73629fa0abf40"}
+legion = { git="https://github.com/jaynus/legion", branch="fix_tag"}
+log = "^ 0.4"
 #wgpu = { git="https://github.com/gfx-rs/wgpu-rs.git", rev="697393df4793e1a58578209885036114adfb9213" }
 wgpu = { git="https://github.com/terrence2/wgpu-rs.git", branch="tdc/wgpu-work-head" }
 #wgpu = { path="/home/terrence/Projects/wgpu-rs" }

--- a/libs/render-wgpu/buffer/shape_instance/src/components.rs
+++ b/libs/render-wgpu/buffer/shape_instance/src/components.rs
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
-use crate::SlotId;
+use crate::{SlotId, TransformType};
 use shape_chunk::{DrawState, ShapeErrata, ShapeId};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -42,11 +42,13 @@ impl ShapeComponent {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ShapeTransformBuffer {
-    pub buffer: [f32; 6],
+    pub buffer: TransformType,
 }
 impl Default for ShapeTransformBuffer {
     fn default() -> Self {
-        Self { buffer: [0f32; 6] }
+        Self {
+            buffer: TransformType::default(),
+        }
     }
 }
 

--- a/libs/render-wgpu/buffer/shape_instance/src/components.rs
+++ b/libs/render-wgpu/buffer/shape_instance/src/components.rs
@@ -16,25 +16,32 @@ use crate::{SlotId, TransformType};
 use shape_chunk::{DrawState, ShapeErrata, ShapeId};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ShapeRefComp {
+pub struct ShapeRef {
     pub shape_id: ShapeId,
 }
-
-impl ShapeRefComp {
+impl ShapeRef {
     pub fn new(shape_id: ShapeId) -> Self {
         Self { shape_id }
     }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ShapeComponent {
+pub struct ShapeSlot {
     pub slot_id: SlotId,
+}
+impl ShapeSlot {
+    pub fn new(slot_id: SlotId) -> Self {
+        Self { slot_id }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ShapeState {
     pub draw_state: DrawState,
 }
-impl ShapeComponent {
-    pub fn new(slot_id: SlotId, errata: ShapeErrata) -> Self {
+impl ShapeState {
+    pub fn new(errata: ShapeErrata) -> Self {
         Self {
-            slot_id,
             draw_state: DrawState::new(errata),
         }
     }

--- a/libs/render-wgpu/render_pass/shape/shaders/shape.vert.glsl
+++ b/libs/render-wgpu/render_pass/shape/shaders/shape.vert.glsl
@@ -32,7 +32,6 @@ layout(location = 1) smooth out vec2 v_tex_coord;
 layout(location = 2) flat out uint f_flags0;
 layout(location = 3) flat out uint f_flags1;
 
-
 // Per shape input
 const uint MAX_XFORM_ID = 32;
 layout(set = 2, binding = 0) buffer ShapeInstanceBlockTransforms {
@@ -44,7 +43,7 @@ layout(set = 2, binding = 1) buffer ShapeInstanceBlockFlags {
 layout(set = 2, binding = 2) buffer ShapeInstanceBlockXformOffsets {
     uint shape_xform_offsets[];
 };
-layout(set = 2, binding = 2) buffer ShapeInstanceBlockXforms {
+layout(set = 2, binding = 3) buffer ShapeInstanceBlockXforms {
     float shape_xforms[];
 };
 

--- a/libs/render-wgpu/render_pass/shape/shaders/shape.vert.glsl
+++ b/libs/render-wgpu/render_pass/shape/shaders/shape.vert.glsl
@@ -48,25 +48,25 @@ layout(set = 2, binding = 3) buffer ShapeInstanceBlockXforms {
 };
 
 void main() {
-    uint base_transform = gl_InstanceIndex * 6;
-    float transform[6] = {
+    uint base_transform = gl_InstanceIndex * 8;
+    float transform[8] = {
         shape_transforms[base_transform + 0],
         shape_transforms[base_transform + 1],
         shape_transforms[base_transform + 2],
         shape_transforms[base_transform + 3],
         shape_transforms[base_transform + 4],
-        shape_transforms[base_transform + 5]
+        shape_transforms[base_transform + 5],
+        shape_transforms[base_transform + 6],
+        shape_transforms[base_transform + 7]
     };
 
-    float xform[6] = {0, 0, 0, 0, 0, 0};
+    float xform[8] = {0, 0, 0, 0, 0, 0, 1, 0};
     if (xform_id < MAX_XFORM_ID) {
-        uint base_xform = shape_xform_offsets[gl_InstanceIndex];
-        xform[0] = shape_xforms[6 * base_xform + 6 * xform_id + 0];
-        xform[1] = shape_xforms[6 * base_xform + 6 * xform_id + 1];
-        xform[2] = shape_xforms[6 * base_xform + 6 * xform_id + 2];
-        xform[3] = shape_xforms[6 * base_xform + 6 * xform_id + 3];
-        xform[4] = shape_xforms[6 * base_xform + 6 * xform_id + 4];
-        xform[5] = shape_xforms[6 * base_xform + 6 * xform_id + 5];
+        uint base_shape_xform = shape_xform_offsets[gl_InstanceIndex];
+        uint offset = 6 * base_shape_xform + 6 * xform_id;
+        for (uint i = 0; i < 6; ++i) {
+            xform[i] = shape_xforms[offset + i];
+        }
     }
 
     gl_Position = camera_projection() *

--- a/libs/universe/Cargo.toml
+++ b/libs/universe/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Terrence Cole <terrence.d.cole@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-legion = { git="https://github.com/TomGillen/legion", rev="23a0b29c0ddefa05dcde39fc0ce73629fa0abf40"}
+#legion = { git="https://github.com/TomGillen/legion", rev="23a0b29c0ddefa05dcde39fc0ce73629fa0abf40"}
+legion = { git="https://github.com/jaynus/legion", branch="fix_tag"}
 nalgebra = "^ 0.18"

--- a/libs/universe/src/component/scale.rs
+++ b/libs/universe/src/component/scale.rs
@@ -15,3 +15,14 @@
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Scale(f32);
+
+impl Scale {
+    pub fn new(v: f32) -> Self {
+        Self(v)
+    }
+
+    // Convert to dense pack for upload.
+    pub fn compact(self) -> [f32; 1] {
+        [self.0]
+    }
+}


### PR DESCRIPTION
We hit one of Legion's sharp edges. If you try to query for a Tag value, it appears to work, but actually just hands you a default value, even if the entity is tagged with a valid value. I think that tags need to only be used as query filters. This is not what we actually want for the shape references. I'm not sure why they'd use this as an example, as I think many people will be similarly confused. At least they renamed it to Tag instead of Shared, so already improving.