### PR TITLE
Traverse with sibling context

### DIFF
--- a/apps/show-sky/src/main.rs
+++ b/apps/show-sky/src/main.rs
@@ -74,7 +74,7 @@ fn main() -> Fallible<()> {
     let mut gpu = GPU::new(&input, Default::default())?;
 
     let detail = if cfg!(debug_assertions) {
-        CpuDetailLevel::Low
+        CpuDetailLevel::Lowest
     } else {
         CpuDetailLevel::Medium
     };

--- a/libs/render-shared/common/geometry/src/algorithm.rs
+++ b/libs/render-shared/common/geometry/src/algorithm.rs
@@ -64,6 +64,10 @@ pub fn compute_normal<T: RealField>(p0: &Point3<T>, p1: &Point3<T>, p2: &Point3<
         .normalize()
 }
 
+pub fn bisect_edge<T: RealField>(v0: &Vector3<T>, v1: &Vector3<T>) -> Vector3<T> {
+    v0 + ((v1 - v0) / convert::<f64, T>(2.0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libs/render-shared/common/geometry/src/ico_sphere.rs
+++ b/libs/render-shared/common/geometry/src/ico_sphere.rs
@@ -14,6 +14,7 @@
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
 #![allow(unused)]
 
+use crate::algorithm::bisect_edge;
 use nalgebra::Vector3;
 
 pub struct Face {
@@ -106,9 +107,9 @@ impl IcoSphere {
         for _ in 0..iterations {
             let mut next_faces = Vec::new();
             for face in &faces {
-                let a = Self::bisect_edge(&verts[face.i0()], &verts[face.i1()]).normalize();
-                let b = Self::bisect_edge(&verts[face.i1()], &verts[face.i2()]).normalize();
-                let c = Self::bisect_edge(&verts[face.i2()], &verts[face.i0()]).normalize();
+                let a = bisect_edge(&verts[face.i0()], &verts[face.i1()]).normalize();
+                let b = bisect_edge(&verts[face.i1()], &verts[face.i2()]).normalize();
+                let c = bisect_edge(&verts[face.i2()], &verts[face.i0()]).normalize();
 
                 let ia = verts.len() as u32;
                 verts.push(a);
@@ -126,10 +127,6 @@ impl IcoSphere {
         }
 
         IcoSphere { verts, faces }
-    }
-
-    pub fn bisect_edge(v0: &Vector3<f64>, v1: &Vector3<f64>) -> Vector3<f64> {
-        v0 + ((v1 - v0) / 2f64)
     }
 }
 

--- a/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
@@ -1,0 +1,131 @@
+// This file is part of OpenFA.
+//
+// OpenFA is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// OpenFA is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
+#![allow(unused)]
+
+use nalgebra::{convert, RealField, Vector3};
+
+pub struct Face<T: RealField> {
+    pub index0: u32,
+    pub index1: u32,
+    pub index2: u32,
+    pub normal: Vector3<T>,
+    pub siblings: [usize; 3], // 0-1, 1-2, 2-0
+}
+
+impl<T: RealField> Face<T> {
+    pub fn new(
+        i0: u32,
+        i1: u32,
+        i2: u32,
+        verts: &[Vector3<T>],
+        sib01: usize,
+        sib12: usize,
+        sib20: usize,
+    ) -> Self {
+        let v0 = &verts[i0 as usize];
+        let v1 = &verts[i1 as usize];
+        let v2 = &verts[i2 as usize];
+        let normal = (v1 - v0).cross(&(v2 - v0)).normalize();
+        Face {
+            index0: i0,
+            index1: i1,
+            index2: i2,
+            normal,
+            siblings: [sib01, sib12, sib20],
+        }
+    }
+
+    pub fn i0(&self) -> usize {
+        self.index0 as usize
+    }
+
+    pub fn i1(&self) -> usize {
+        self.index1 as usize
+    }
+
+    pub fn i2(&self) -> usize {
+        self.index2 as usize
+    }
+}
+
+pub struct Icosahedron<T: RealField> {
+    pub verts: Vec<Vector3<T>>,
+    pub faces: Vec<Face<T>>,
+}
+
+impl<T: RealField> Icosahedron<T> {
+    pub fn new() -> Self {
+        let t = (T::one() + convert::<f64, T>(5.0).sqrt()) / convert::<f64, T>(2.0);
+
+        // The bones of the d12 are 3 orthogonal quads at the origin.
+        let mut verts = vec![
+            Vector3::new(-T::one(), t, T::zero()).normalize(),
+            Vector3::new(T::one(), t, T::zero()).normalize(),
+            Vector3::new(-T::one(), -t, T::zero()).normalize(),
+            Vector3::new(T::one(), -t, T::zero()).normalize(),
+            Vector3::new(T::zero(), -T::one(), t).normalize(),
+            Vector3::new(T::zero(), T::one(), t).normalize(),
+            Vector3::new(T::zero(), -T::one(), -t).normalize(),
+            Vector3::new(T::zero(), T::one(), -t).normalize(),
+            Vector3::new(t, T::zero(), -T::one()).normalize(),
+            Vector3::new(t, T::zero(), T::one()).normalize(),
+            Vector3::new(-t, T::zero(), -T::one()).normalize(),
+            Vector3::new(-t, T::zero(), T::one()).normalize(),
+        ];
+
+        let mut faces = vec![
+            // -- 5 faces around point 0
+            /* 0 */
+            Face::new(0, 11, 5, &verts, 4, 6, 1),
+            /* 1 */ Face::new(0, 5, 1, &verts, 0, 5, 2),
+            /* 2 */ Face::new(0, 1, 7, &verts, 1, 9, 3),
+            /* 3 */ Face::new(0, 7, 10, &verts, 2, 8, 4),
+            /* 4 */ Face::new(0, 10, 11, &verts, 3, 7, 0),
+            // -- 5 adjacent faces
+            /* 5 */ Face::new(1, 5, 9, &verts, 1, 15, 19),
+            /* 6 */ Face::new(5, 11, 4, &verts, 0, 16, 15),
+            /* 7 */ Face::new(11, 10, 2, &verts, 4, 17, 16),
+            /* 8 */ Face::new(10, 7, 6, &verts, 3, 18, 17),
+            /* 9 */ Face::new(7, 1, 8, &verts, 2, 19, 18),
+            // -- 5 faces around point 3
+            /* 10 */
+            Face::new(3, 9, 4, &verts, 14, 15, 11),
+            /* 11 */ Face::new(3, 4, 2, &verts, 10, 16, 12),
+            /* 12 */ Face::new(3, 2, 6, &verts, 11, 17, 13),
+            /* 13 */ Face::new(3, 6, 8, &verts, 12, 18, 14),
+            /* 14 */ Face::new(3, 8, 9, &verts, 13, 19, 10),
+            // -- 5 adjacent faces
+            /* 15 */ Face::new(4, 9, 5, &verts, 10, 5, 6),
+            /* 16 */ Face::new(2, 4, 11, &verts, 11, 6, 7),
+            /* 17 */ Face::new(6, 2, 10, &verts, 12, 7, 8),
+            /* 18 */ Face::new(8, 6, 7, &verts, 13, 8, 9),
+            /* 19 */ Face::new(9, 8, 1, &verts, 14, 9, 5),
+        ];
+
+        Self { verts, faces }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_can_be_created() {
+        let ico = Icosahedron::<f64>::new();
+        assert_eq!(ico.verts.len(), 12);
+        assert_eq!(ico.faces.len(), 20);
+    }
+}

--- a/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
@@ -52,6 +52,7 @@ const DBG_COLORS_BY_LEVEL: [[f32; 3]; 19] = [
 ];
 
 pub enum CpuDetailLevel {
+    Lowest,
     Low,
     Medium,
 }
@@ -60,7 +61,8 @@ impl CpuDetailLevel {
     // max-level, buffer-size, falloff-coefficient
     fn parameters(&self) -> (usize, f64, usize) {
         match self {
-            Self::Low => (8, 0.8, 256),
+            Self::Lowest => (5, 0.8, 512),
+            Self::Low => (8, 0.8, 512),
             Self::Medium => (14, 0.8, 768),
         }
     }

--- a/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
 mod debug_vertex;
+mod icosahedron;
 mod patch;
 mod patch_tree;
 mod patch_vertex;

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch.rs
@@ -225,37 +225,12 @@ impl Patch {
         true
     }
 
-    // FIXME: Fuzz offset needs to be the extent of the possible normals of the patch.
-    /*
-    fn is_back_facing(&self, eye_position: &Point3<f64>) -> bool {
-        for p in &self.pts {
-            if (p - eye_position).dot(&self.normal) <= -0.00001f64 {
-                return false;
-            }
-        }
-        true
-    }
-     */
-
-    pub(crate) fn keep(
-        &self,
-        viewable_area: &[Plane<f64>; 6],
-        _eye_position: &Point3<f64>,
-    ) -> bool {
-        /*
-        // Cull back-facing
-        if self.is_back_facing(eye_position) {
-            // println!("  no - back facing");
-            return false;
-        }
-        */
-
+    pub(crate) fn keep(&self, viewable_area: &[Plane<f64>; 6]) -> bool {
         for plane in viewable_area {
             if self.is_behind_plane(plane, false) {
                 return false;
             }
         }
-
         true
     }
 }

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
@@ -12,11 +12,11 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
-use crate::patch::Patch;
+use crate::{icosahedron::Icosahedron, patch::Patch};
 
 use absolute_unit::Kilometers;
 use camera::ArcBallCamera;
-use geometry::{IcoSphere, Plane};
+use geometry::{algorithm::bisect_edge, Plane};
 use nalgebra::{Point3, Vector3};
 use physical_constants::EARTH_RADIUS_KM;
 use std::{cmp::Reverse, collections::BinaryHeap, time::Instant};
@@ -159,7 +159,7 @@ impl PatchTree {
             depth_levels.push(d * d);
         }
 
-        let sphere = IcoSphere::new(0);
+        let sphere = Icosahedron::new();
         let cached_eye_position = Point3::new(0f64, 0f64, 0f64);
         let cached_eye_direction = Vector3::new(1f64, 0f64, 0f64);
         let cached_viewable_region =
@@ -407,15 +407,9 @@ impl PatchTree {
         let parent = self.tree_node(self.get_patch(patch_index).owner()).parent();
 
         // Get new points.
-        let a = Point3::from(
-            IcoSphere::bisect_edge(&v0.coords, &v1.coords).normalize() * EARTH_RADIUS_KM,
-        );
-        let b = Point3::from(
-            IcoSphere::bisect_edge(&v1.coords, &v2.coords).normalize() * EARTH_RADIUS_KM,
-        );
-        let c = Point3::from(
-            IcoSphere::bisect_edge(&v2.coords, &v0.coords).normalize() * EARTH_RADIUS_KM,
-        );
+        let a = Point3::from(bisect_edge(&v0.coords, &v1.coords).normalize() * EARTH_RADIUS_KM);
+        let b = Point3::from(bisect_edge(&v1.coords, &v2.coords).normalize() * EARTH_RADIUS_KM);
+        let c = Point3::from(bisect_edge(&v2.coords, &v0.coords).normalize() * EARTH_RADIUS_KM);
 
         // Allocate geometry to new patches.
         let children = [


### PR DESCRIPTION
Keep enough context to ensure we can tesselate correctly and to select the right mesh when it comes time to draw.