### PR TITLE
Peer-aware depth-first traversal

### DIFF
--- a/libs/render-shared/common/geometry/src/algorithm.rs
+++ b/libs/render-shared/common/geometry/src/algorithm.rs
@@ -64,6 +64,10 @@ pub fn compute_normal<T: RealField>(p0: &Point3<T>, p1: &Point3<T>, p2: &Point3<
         .normalize()
 }
 
+pub fn bisect_edge<T: RealField>(v0: &Vector3<T>, v1: &Vector3<T>) -> Vector3<T> {
+    v0 + ((v1 - v0) / convert::<f64, T>(2f64))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libs/render-shared/common/geometry/src/ico_sphere.rs
+++ b/libs/render-shared/common/geometry/src/ico_sphere.rs
@@ -12,8 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
-#![allow(unused)]
-
+use crate::algorithm::bisect_edge;
 use nalgebra::Vector3;
 
 pub struct Face {
@@ -106,9 +105,9 @@ impl IcoSphere {
         for _ in 0..iterations {
             let mut next_faces = Vec::new();
             for face in &faces {
-                let a = Self::bisect_edge(&verts[face.i0()], &verts[face.i1()]).normalize();
-                let b = Self::bisect_edge(&verts[face.i1()], &verts[face.i2()]).normalize();
-                let c = Self::bisect_edge(&verts[face.i2()], &verts[face.i0()]).normalize();
+                let a = bisect_edge(&verts[face.i0()], &verts[face.i1()]).normalize();
+                let b = bisect_edge(&verts[face.i1()], &verts[face.i2()]).normalize();
+                let c = bisect_edge(&verts[face.i2()], &verts[face.i0()]).normalize();
 
                 let ia = verts.len() as u32;
                 verts.push(a);
@@ -126,10 +125,6 @@ impl IcoSphere {
         }
 
         IcoSphere { verts, faces }
-    }
-
-    pub fn bisect_edge(v0: &Vector3<f64>, v1: &Vector3<f64>) -> Vector3<f64> {
-        v0 + ((v1 - v0) / 2f64)
     }
 }
 

--- a/libs/render-wgpu/buffer/terrain_geo/Cargo.toml
+++ b/libs/render-wgpu/buffer/terrain_geo/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Terrence Cole <terrence.d.cole@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+approx = "^ 0.3"
 failure = "^ 0.1.2"
 memoffset = "^ 0.5"
 nalgebra = "^ 0.20"

--- a/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
@@ -12,9 +12,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
-#![allow(unused)]
-
-use failure::_core::hint::unreachable_unchecked;
 use nalgebra::{convert, RealField, Vector3};
 
 pub struct Face<T: RealField> {
@@ -80,7 +77,7 @@ impl<T: RealField> Icosahedron<T> {
         let t = (T::one() + convert::<f64, T>(5.0).sqrt()) / convert::<f64, T>(2.0);
 
         // The bones of the d12 are 3 orthogonal quads at the origin.
-        let mut verts = vec![
+        let verts = vec![
             Vector3::new(-T::one(), t, T::zero()).normalize(),
             Vector3::new(T::one(), t, T::zero()).normalize(),
             Vector3::new(-T::one(), -t, T::zero()).normalize(),
@@ -95,7 +92,7 @@ impl<T: RealField> Icosahedron<T> {
             Vector3::new(-t, T::zero(), T::one()).normalize(),
         ];
 
-        let mut faces = vec![
+        let faces = vec![
             // -- 5 faces around point 0
             /* 0 */
             Face::new(0, 11, 5, &verts, [4, 2], [6, 0], [1, 0]),

--- a/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
@@ -133,8 +133,14 @@ mod test {
         for (i, face) in ico.faces.iter().enumerate() {
             println!("at face: {:?}", i);
             for (j, [sib, peer_edge, ..]) in face.siblings.iter().enumerate() {
-                assert_eq!(face.edge(j)[0], ico.faces[*sib].edge(*peer_edge)[1]);
-                assert_eq!(face.edge(j)[1], ico.faces[*sib].edge(*peer_edge)[0]);
+                assert_eq!(
+                    face.edge(j)[0],
+                    ico.faces[*sib as usize].edge(*peer_edge as usize)[1]
+                );
+                assert_eq!(
+                    face.edge(j)[1],
+                    ico.faces[*sib as usize].edge(*peer_edge as usize)[0]
+                );
             }
         }
     }

--- a/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
@@ -15,48 +15,37 @@
 use nalgebra::{convert, RealField, Vector3};
 
 pub struct Face<T: RealField> {
-    pub index0: u32,
-    pub index1: u32,
-    pub index2: u32,
+    pub indices: [u8; 3],
     pub normal: Vector3<T>,
-    pub siblings: [[usize; 2]; 3], // 0-1, 1-2, 2-0
+    pub siblings: [[u8; 2]; 3], // 0-1, 1-2, 2-0
 }
 
 impl<T: RealField> Face<T> {
-    pub fn new(
-        i0: u32,
-        i1: u32,
-        i2: u32,
-        verts: &[Vector3<T>],
-        sib01: [usize; 2],
-        sib12: [usize; 2],
-        sib20: [usize; 2],
-    ) -> Self {
-        let v0 = &verts[i0 as usize];
-        let v1 = &verts[i1 as usize];
-        let v2 = &verts[i2 as usize];
+    pub fn new(indices: [u8; 3], verts: &[Vector3<T>], siblings: [[u8; 2]; 3]) -> Self {
+        let v0 = &verts[indices[0] as usize];
+        let v1 = &verts[indices[1] as usize];
+        let v2 = &verts[indices[2] as usize];
         let normal = (v1 - v0).cross(&(v2 - v0)).normalize();
         Face {
-            index0: i0,
-            index1: i1,
-            index2: i2,
+            indices,
             normal,
-            siblings: [sib01, sib12, sib20],
+            siblings,
         }
     }
 
     pub fn i0(&self) -> usize {
-        self.index0 as usize
+        self.indices[0] as usize
     }
 
     pub fn i1(&self) -> usize {
-        self.index1 as usize
+        self.indices[1] as usize
     }
 
     pub fn i2(&self) -> usize {
-        self.index2 as usize
+        self.indices[2] as usize
     }
 
+    #[allow(unused)]
     pub fn edge(&self, i: usize) -> [usize; 2] {
         match i {
             0 => [self.i0(), self.i1()],
@@ -64,6 +53,10 @@ impl<T: RealField> Face<T> {
             2 => [self.i2(), self.i0()],
             _ => unreachable!(),
         }
+    }
+
+    pub fn sibling(&self, i: usize) -> (usize, u8) {
+        (self.siblings[i][0] as usize, self.siblings[i][1])
     }
 }
 
@@ -95,32 +88,32 @@ impl<T: RealField> Icosahedron<T> {
         let faces = vec![
             // -- 5 faces around point 0
             /* 0 */
-            Face::new(0, 11, 5, &verts, [4, 2], [6, 0], [1, 0]),
-            /* 1 */ Face::new(0, 5, 1, &verts, [0, 2], [5, 0], [2, 0]),
-            /* 2 */ Face::new(0, 1, 7, &verts, [1, 2], [9, 0], [3, 0]),
-            /* 3 */ Face::new(0, 7, 10, &verts, [2, 2], [8, 0], [4, 0]),
-            /* 4 */ Face::new(0, 10, 11, &verts, [3, 2], [7, 0], [0, 0]),
+            Face::new([0, 11, 5], &verts, [[4, 2], [6, 0], [1, 0]]),
+            /* 1 */ Face::new([0, 5, 1], &verts, [[0, 2], [5, 0], [2, 0]]),
+            /* 2 */ Face::new([0, 1, 7], &verts, [[1, 2], [9, 0], [3, 0]]),
+            /* 3 */ Face::new([0, 7, 10], &verts, [[2, 2], [8, 0], [4, 0]]),
+            /* 4 */ Face::new([0, 10, 11], &verts, [[3, 2], [7, 0], [0, 0]]),
             // -- 5 adjacent faces
             /* 5 */
-            Face::new(1, 5, 9, &verts, [1, 1], [15, 1], [19, 2]),
-            /* 6 */ Face::new(5, 11, 4, &verts, [0, 1], [16, 1], [15, 2]),
-            /* 7 */ Face::new(11, 10, 2, &verts, [4, 1], [17, 1], [16, 2]),
-            /* 8 */ Face::new(10, 7, 6, &verts, [3, 1], [18, 1], [17, 2]),
-            /* 9 */ Face::new(7, 1, 8, &verts, [2, 1], [19, 1], [18, 2]),
+            Face::new([1, 5, 9], &verts, [[1, 1], [15, 1], [19, 2]]),
+            /* 6 */ Face::new([5, 11, 4], &verts, [[0, 1], [16, 1], [15, 2]]),
+            /* 7 */ Face::new([11, 10, 2], &verts, [[4, 1], [17, 1], [16, 2]]),
+            /* 8 */ Face::new([10, 7, 6], &verts, [[3, 1], [18, 1], [17, 2]]),
+            /* 9 */ Face::new([7, 1, 8], &verts, [[2, 1], [19, 1], [18, 2]]),
             // -- 5 faces around point 3
             /* 10 */
-            Face::new(3, 9, 4, &verts, [14, 2], [15, 0], [11, 0]),
-            /* 11 */ Face::new(3, 4, 2, &verts, [10, 2], [16, 0], [12, 0]),
-            /* 12 */ Face::new(3, 2, 6, &verts, [11, 2], [17, 0], [13, 0]),
-            /* 13 */ Face::new(3, 6, 8, &verts, [12, 2], [18, 0], [14, 0]),
-            /* 14 */ Face::new(3, 8, 9, &verts, [13, 2], [19, 0], [10, 0]),
+            Face::new([3, 9, 4], &verts, [[14, 2], [15, 0], [11, 0]]),
+            /* 11 */ Face::new([3, 4, 2], &verts, [[10, 2], [16, 0], [12, 0]]),
+            /* 12 */ Face::new([3, 2, 6], &verts, [[11, 2], [17, 0], [13, 0]]),
+            /* 13 */ Face::new([3, 6, 8], &verts, [[12, 2], [18, 0], [14, 0]]),
+            /* 14 */ Face::new([3, 8, 9], &verts, [[13, 2], [19, 0], [10, 0]]),
             // -- 5 adjacent faces
             /* 15 */
-            Face::new(4, 9, 5, &verts, [10, 1], [5, 1], [6, 2]),
-            /* 16 */ Face::new(2, 4, 11, &verts, [11, 1], [6, 1], [7, 2]),
-            /* 17 */ Face::new(6, 2, 10, &verts, [12, 1], [7, 1], [8, 2]),
-            /* 18 */ Face::new(8, 6, 7, &verts, [13, 1], [8, 1], [9, 2]),
-            /* 19 */ Face::new(9, 8, 1, &verts, [14, 1], [9, 1], [5, 2]),
+            Face::new([4, 9, 5], &verts, [[10, 1], [5, 1], [6, 2]]),
+            /* 16 */ Face::new([2, 4, 11], &verts, [[11, 1], [6, 1], [7, 2]]),
+            /* 17 */ Face::new([6, 2, 10], &verts, [[12, 1], [7, 1], [8, 2]]),
+            /* 18 */ Face::new([8, 6, 7], &verts, [[13, 1], [8, 1], [9, 2]]),
+            /* 19 */ Face::new([9, 8, 1], &verts, [[14, 1], [9, 1], [5, 2]]),
         ];
 
         Self { verts, faces }

--- a/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/icosahedron.rs
@@ -1,0 +1,151 @@
+// This file is part of OpenFA.
+//
+// OpenFA is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// OpenFA is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
+#![allow(unused)]
+
+use failure::_core::hint::unreachable_unchecked;
+use nalgebra::{convert, RealField, Vector3};
+
+pub struct Face<T: RealField> {
+    pub index0: u32,
+    pub index1: u32,
+    pub index2: u32,
+    pub normal: Vector3<T>,
+    pub siblings: [[usize; 2]; 3], // 0-1, 1-2, 2-0
+}
+
+impl<T: RealField> Face<T> {
+    pub fn new(
+        i0: u32,
+        i1: u32,
+        i2: u32,
+        verts: &[Vector3<T>],
+        sib01: [usize; 2],
+        sib12: [usize; 2],
+        sib20: [usize; 2],
+    ) -> Self {
+        let v0 = &verts[i0 as usize];
+        let v1 = &verts[i1 as usize];
+        let v2 = &verts[i2 as usize];
+        let normal = (v1 - v0).cross(&(v2 - v0)).normalize();
+        Face {
+            index0: i0,
+            index1: i1,
+            index2: i2,
+            normal,
+            siblings: [sib01, sib12, sib20],
+        }
+    }
+
+    pub fn i0(&self) -> usize {
+        self.index0 as usize
+    }
+
+    pub fn i1(&self) -> usize {
+        self.index1 as usize
+    }
+
+    pub fn i2(&self) -> usize {
+        self.index2 as usize
+    }
+
+    pub fn edge(&self, i: usize) -> [usize; 2] {
+        match i {
+            0 => [self.i0(), self.i1()],
+            1 => [self.i1(), self.i2()],
+            2 => [self.i2(), self.i0()],
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub struct Icosahedron<T: RealField> {
+    pub verts: Vec<Vector3<T>>,
+    pub faces: Vec<Face<T>>,
+}
+
+impl<T: RealField> Icosahedron<T> {
+    pub fn new() -> Self {
+        let t = (T::one() + convert::<f64, T>(5.0).sqrt()) / convert::<f64, T>(2.0);
+
+        // The bones of the d12 are 3 orthogonal quads at the origin.
+        let mut verts = vec![
+            Vector3::new(-T::one(), t, T::zero()).normalize(),
+            Vector3::new(T::one(), t, T::zero()).normalize(),
+            Vector3::new(-T::one(), -t, T::zero()).normalize(),
+            Vector3::new(T::one(), -t, T::zero()).normalize(),
+            Vector3::new(T::zero(), -T::one(), t).normalize(),
+            Vector3::new(T::zero(), T::one(), t).normalize(),
+            Vector3::new(T::zero(), -T::one(), -t).normalize(),
+            Vector3::new(T::zero(), T::one(), -t).normalize(),
+            Vector3::new(t, T::zero(), -T::one()).normalize(),
+            Vector3::new(t, T::zero(), T::one()).normalize(),
+            Vector3::new(-t, T::zero(), -T::one()).normalize(),
+            Vector3::new(-t, T::zero(), T::one()).normalize(),
+        ];
+
+        let mut faces = vec![
+            // -- 5 faces around point 0
+            /* 0 */
+            Face::new(0, 11, 5, &verts, [4, 2], [6, 0], [1, 0]),
+            /* 1 */ Face::new(0, 5, 1, &verts, [0, 2], [5, 0], [2, 0]),
+            /* 2 */ Face::new(0, 1, 7, &verts, [1, 2], [9, 0], [3, 0]),
+            /* 3 */ Face::new(0, 7, 10, &verts, [2, 2], [8, 0], [4, 0]),
+            /* 4 */ Face::new(0, 10, 11, &verts, [3, 2], [7, 0], [0, 0]),
+            // -- 5 adjacent faces
+            /* 5 */
+            Face::new(1, 5, 9, &verts, [1, 1], [15, 1], [19, 2]),
+            /* 6 */ Face::new(5, 11, 4, &verts, [0, 1], [16, 1], [15, 2]),
+            /* 7 */ Face::new(11, 10, 2, &verts, [4, 1], [17, 1], [16, 2]),
+            /* 8 */ Face::new(10, 7, 6, &verts, [3, 1], [18, 1], [17, 2]),
+            /* 9 */ Face::new(7, 1, 8, &verts, [2, 1], [19, 1], [18, 2]),
+            // -- 5 faces around point 3
+            /* 10 */
+            Face::new(3, 9, 4, &verts, [14, 2], [15, 0], [11, 0]),
+            /* 11 */ Face::new(3, 4, 2, &verts, [10, 2], [16, 0], [12, 0]),
+            /* 12 */ Face::new(3, 2, 6, &verts, [11, 2], [17, 0], [13, 0]),
+            /* 13 */ Face::new(3, 6, 8, &verts, [12, 2], [18, 0], [14, 0]),
+            /* 14 */ Face::new(3, 8, 9, &verts, [13, 2], [19, 0], [10, 0]),
+            // -- 5 adjacent faces
+            /* 15 */
+            Face::new(4, 9, 5, &verts, [10, 1], [5, 1], [6, 2]),
+            /* 16 */ Face::new(2, 4, 11, &verts, [11, 1], [6, 1], [7, 2]),
+            /* 17 */ Face::new(6, 2, 10, &verts, [12, 1], [7, 1], [8, 2]),
+            /* 18 */ Face::new(8, 6, 7, &verts, [13, 1], [8, 1], [9, 2]),
+            /* 19 */ Face::new(9, 8, 1, &verts, [14, 1], [9, 1], [5, 2]),
+        ];
+
+        Self { verts, faces }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn icosahedron_peer_linkage() {
+        let ico = Icosahedron::<f64>::new();
+        assert_eq!(ico.verts.len(), 12);
+        assert_eq!(ico.faces.len(), 20);
+
+        for (i, face) in ico.faces.iter().enumerate() {
+            println!("at face: {:?}", i);
+            for (j, [sib, peer_edge, ..]) in face.siblings.iter().enumerate() {
+                assert_eq!(face.edge(j)[0], ico.faces[*sib].edge(*peer_edge)[1]);
+                assert_eq!(face.edge(j)[1], ico.faces[*sib].edge(*peer_edge)[0]);
+            }
+        }
+    }
+}

--- a/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
 mod debug_vertex;
+mod icosahedron;
 mod patch;
 mod patch_tree;
 mod patch_vertex;

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch.rs
@@ -93,6 +93,15 @@ impl Patch {
         &self.pts
     }
 
+    pub(crate) fn edge(&self, i: u8) -> (Point3<f64>, Point3<f64>) {
+        match i {
+            0 => (self.pts[0], self.pts[1]),
+            1 => (self.pts[1], self.pts[2]),
+            2 => (self.pts[2], self.pts[0]),
+            _ => unreachable!(),
+        }
+    }
+
     pub(crate) fn distance_squared_to(&self, point: &Point3<f64>) -> f64 {
         if self.point_is_in_cone(point) {
             let m = point.coords.magnitude();

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
@@ -159,11 +159,6 @@ impl PatchTree {
         }
 
         let sphere = IcoSphere::new(0);
-        let cached_eye_position = Point3::new(0f64, 0f64, 0f64);
-        let cached_eye_direction = Vector3::new(1f64, 0f64, 0f64);
-        let cached_viewable_region =
-            [Plane::from_normal_and_distance(Vector3::new(1f64, 0f64, 0f64), 0f64); 6];
-
         let mut patches = Vec::new();
         let mut tree = Vec::new();
         let mut root = Root {
@@ -197,9 +192,12 @@ impl PatchTree {
             subdivide_count: 0,
             rejoin_count: 0,
             visit_count: 0,
-            cached_viewable_region,
-            cached_eye_position,
-            cached_eye_direction,
+            cached_viewable_region: [Plane::from_normal_and_distance(
+                Vector3::new(1f64, 0f64, 0f64),
+                0f64,
+            ); 6],
+            cached_eye_position: Point3::new(0f64, 0f64, 0f64),
+            cached_eye_direction: Vector3::new(1f64, 0f64, 0f64),
         }
     }
 

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
@@ -459,9 +459,10 @@ impl PatchTree {
                     return;
                 }
 
-                if node.children.iter().all(|i| {
+                let outside = node.children.iter().all(|i| {
                     self.leaf_is_outside_distance_function(&self.cached_eye_position, level + 1, *i)
-                }) {
+                });
+                if outside {
                     self.rejoin_leaf_patch_into(
                         node.parent,
                         node.level,


### PR DESCRIPTION
This is something we need to support in order to both determine what index buffer to use when displaying, as well as to be able to avoid subdividing past one level of difference between adjacent tiles. 