### PR TITLE
Track patch liveness externally.

### DIFF
--- a/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
@@ -195,7 +195,6 @@ impl TerrainGeoBuffer {
             if offset >= self.patch_buffer_size {
                 continue;
             }
-            assert!(patch.is_alive());
             let [v0, v1, v2] = patch.points();
             let n0 = v0.coords.normalize();
             let n1 = v1.coords.normalize();

--- a/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/lib.rs
@@ -71,7 +71,7 @@ pub struct TerrainGeoBuffer {
     // Maximum number of patches for the patch buffer.
     patch_buffer_size: usize,
 
-    patches: PatchTree,
+    patch_tree: PatchTree,
 
     // bind_group_layout: wgpu::BindGroupLayout,
     // bind_group: wgpu::BindGroup,
@@ -113,7 +113,7 @@ impl TerrainGeoBuffer {
         });
         */
 
-        let patches = PatchTree::new(max_level, patch_buffer_size);
+        let patch_tree = PatchTree::new(max_level, patch_buffer_size);
 
         println!(
             "dbg_vertex_buffer: {:08X}",
@@ -166,7 +166,7 @@ impl TerrainGeoBuffer {
 
         Ok(Arc::new(RefCell::new(Self {
             patch_buffer_size,
-            patches,
+            patch_tree,
 
             patch_vertex_buffer,
             patch_index_buffer,
@@ -187,11 +187,11 @@ impl TerrainGeoBuffer {
         let mut verts = Vec::with_capacity(3 * self.patch_buffer_size);
         let mut dbg_indices = Vec::with_capacity(3 * self.patch_buffer_size);
         let mut live_patches = Vec::with_capacity(self.patch_buffer_size);
-        self.patches.optimize_for_view(camera, &mut live_patches);
+        self.patch_tree.optimize_for_view(camera, &mut live_patches);
         assert!(live_patches.len() < self.patch_buffer_size);
 
         for (offset, i) in live_patches.iter().enumerate() {
-            let patch = self.patches.get_patch(*i);
+            let patch = self.patch_tree.get_patch(*i);
             if offset >= self.patch_buffer_size {
                 continue;
             }
@@ -206,7 +206,7 @@ impl TerrainGeoBuffer {
             dbg_indices.push(dbg_verts.len() as u32);
             dbg_indices.push(dbg_verts.len() as u32 + 1);
             dbg_indices.push(dbg_verts.len() as u32 + 2);
-            let level = self.patches.level_of_patch(*i);
+            let level = self.patch_tree.level_of_patch(*i);
             let clr = DBG_COLORS_BY_LEVEL[level];
             dbg_verts.push(DebugVertex::new(&v0, &n0, &clr));
             dbg_verts.push(DebugVertex::new(&v1, &n1, &clr));

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch.rs
@@ -49,6 +49,17 @@ pub(crate) struct Patch {
 }
 
 impl Patch {
+    pub(crate) fn empty() -> Self {
+        Self {
+            normal: Vector3::new(1f64, 0f64, 0f64),
+            planes: [Plane::from_normal_and_distance(Vector3::new(1f64, 0f64, 0f64), 0f64); 3],
+            pts: [Point3::new(0f64, 0f64, 0f64); 3],
+            owner: TreeIndex(usize::MAX),
+            cached_solid_angle: 0f64,
+            cached_in_view: false,
+        }
+    }
+
     pub(crate) fn new(owner: TreeIndex, pts: [Point3<f64>; 3]) -> Self {
         let origin = Point3::new(0f64, 0f64, 0f64);
         let patch = Self {
@@ -67,6 +78,10 @@ impl Patch {
         assert!(patch.planes[1].point_is_in_front(&pts[0]));
         assert!(patch.planes[2].point_is_in_front(&pts[1]));
         patch
+    }
+
+    pub(crate) fn retarget(&mut self, owner: TreeIndex, pts: [Point3<f64>; 3]) {
+        *self = Self::new(owner, pts);
     }
 
     pub(crate) fn update_for_view(

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
@@ -1028,10 +1028,7 @@ impl PatchTree {
             // Don't split leaves past max level.
             assert!(level <= self.max_level);
             // TODO: Note need to pull out index variant from peer info stored on node.
-            if self
-                .tree_patch(tree_index)
-                .keep(&self.cached_viewable_region)
-            {
+            if self.tree_patch(tree_index).in_view() {
                 live_patches.push(node.patch_index());
             }
         }

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
@@ -572,7 +572,7 @@ impl PatchTree {
         let mut stuck_iterations = 0;
 
         // While T is not the target size/accuracy, or the maximum split priority is greater than the minimum merge priority {
-        while self.max_splittable() - self.min_mergeable() > 150.0
+        while self.max_splittable() - self.min_mergeable() > self.target_refinement
             || self.cached_visible_patches < target_patch_count - 4
             || self.cached_visible_patches > target_patch_count
         {

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
@@ -232,8 +232,7 @@ impl PatchTree {
             let v0 = Point3::from(sphere.verts[face.i0()] * EARTH_RADIUS_KM);
             let v1 = Point3::from(sphere.verts[face.i1()] * EARTH_RADIUS_KM);
             let v2 = Point3::from(sphere.verts[face.i2()] * EARTH_RADIUS_KM);
-            let mut p = Patch::new();
-            p.change_target(TreeIndex(i), [v0, v1, v2]);
+            let p = Patch::new(TreeIndex(i), [v0, v1, v2]);
             patches.push(Some(p));
         }
 
@@ -284,9 +283,7 @@ impl PatchTree {
 
     fn allocate_leaf_patch(&mut self, tree_index: TreeIndex, pts: [Point3<f64>; 3]) -> PatchIndex {
         let patch_index = self.allocate_patch();
-        self.patches[poff(patch_index)] = Some(Patch::new());
-        self.get_patch_mut(patch_index)
-            .change_target(tree_index, pts);
+        self.patches[poff(patch_index)] = Some(Patch::new(tree_index, pts));
         let viewable_region = self.cached_viewable_region;
         let eye_position = self.cached_eye_position;
         let eye_direction = self.cached_eye_direction;

--- a/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/patch_tree.rs
@@ -606,14 +606,14 @@ impl PatchTree {
         }
         assert!(self.cached_visible_patches <= target_patch_count);
 
+        // Prepare for next frame.
+        self.compact_patches();
+
         // Build a view-direction independent tesselation based on the current camera position.
         self.capture_patches(live_patches);
         assert!(live_patches.len() <= target_patch_count);
         assert_eq!(self.cached_visible_patches, live_patches.len());
         let reshape_time = Instant::now() - reshape_start;
-
-        // Prepare for next frame.
-        self.compact_patches();
 
         // Select patches based on visibility.
         let max_split = self.max_splittable();

--- a/libs/render-wgpu/buffer/terrain_geo/src/queue.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/queue.rs
@@ -14,7 +14,7 @@
 // along with OpenFA.  If not, see <http://www.gnu.org/licenses/>.
 use crate::{
     patch::Patch,
-    patch_tree::{poff, toff, PatchTree, TreeIndex, TreeNode},
+    patch_tree::{toff, PatchTree, TreeIndex, TreeNode},
 };
 use float_ord::FloatOrd;
 use std::{
@@ -219,7 +219,7 @@ impl<T: QueueItem + Ord + fmt::Debug> Queue<T> {
         }
     }
 
-    pub(crate) fn update_cache(&mut self, tree: &[Option<TreeNode>], patches: &[Option<Patch>]) {
+    pub(crate) fn update_cache(&mut self, tree: &[Option<TreeNode>], patches: &[Patch]) {
         let mut sandbag = BinaryHeap::new();
         std::mem::swap(&mut self.heap, &mut sandbag);
         let mut heap_vec = sandbag.into_vec();

--- a/libs/render-wgpu/buffer/terrain_geo/src/queue.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/queue.rs
@@ -225,21 +225,8 @@ impl<T: QueueItem + Ord + fmt::Debug> Queue<T> {
         let mut heap_vec = sandbag.into_vec();
         for key in heap_vec.iter_mut() {
             if !self.removals.contains(&key.tree_index()) {
-                let node = tree[toff(key.tree_index())].expect("freed node in queue");
-                if node.is_leaf() {
-                    key.set_solid_angle(patches[poff(node.patch_index())].unwrap().solid_angle());
-                } else {
-                    // FIXME: shame is an appropriate reaction here
-                    let mut max_sa = f64::MIN;
-                    for &child_index in node.children() {
-                        let child = tree[toff(child_index)].expect("freed child in queue");
-                        let sa = patches[poff(child.patch_index())].unwrap().solid_angle();
-                        if sa > max_sa {
-                            max_sa = sa;
-                        }
-                    }
-                    key.set_solid_angle(max_sa);
-                }
+                let solid_angle = PatchTree::solid_angle_shared(key.tree_index(), tree, patches);
+                key.set_solid_angle(solid_angle);
             }
         }
         // O(n) rebuild of the queue

--- a/libs/render-wgpu/buffer/terrain_geo/src/queue.rs
+++ b/libs/render-wgpu/buffer/terrain_geo/src/queue.rs
@@ -219,7 +219,7 @@ impl<T: QueueItem + Ord + fmt::Debug> Queue<T> {
         }
     }
 
-    pub(crate) fn update_cache(&mut self, tree: &[Option<TreeNode>], patches: &[Patch]) {
+    pub(crate) fn update_cache(&mut self, tree: &[Option<TreeNode>], patches: &[Option<Patch>]) {
         let mut sandbag = BinaryHeap::new();
         std::mem::swap(&mut self.heap, &mut sandbag);
         let mut heap_vec = sandbag.into_vec();
@@ -227,13 +227,13 @@ impl<T: QueueItem + Ord + fmt::Debug> Queue<T> {
             if !self.removals.contains(&key.tree_index()) {
                 let node = tree[toff(key.tree_index())].expect("freed node in queue");
                 if node.is_leaf() {
-                    key.set_solid_angle(patches[poff(node.patch_index())].solid_angle());
+                    key.set_solid_angle(patches[poff(node.patch_index())].unwrap().solid_angle());
                 } else {
                     // FIXME: shame is an appropriate reaction here
                     let mut max_sa = f64::MIN;
                     for &child_index in node.children() {
                         let child = tree[toff(child_index)].expect("freed child in queue");
-                        let sa = patches[poff(child.patch_index())].solid_angle();
+                        let sa = patches[poff(child.patch_index())].unwrap().solid_angle();
                         if sa > max_sa {
                             max_sa = sa;
                         }


### PR DESCRIPTION
We need to track in-view-ness separately from liveness, separately from solid angle in order to pull apart live, in-view patch tracking.